### PR TITLE
remove machine learning repo from here

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "MachineLearning"]
-	path = MachineLearning
-	url = git@github.com:SEAME-pt/Team02-MachineLearning.git


### PR DESCRIPTION
This pull request removes the `MachineLearning` submodule from the repository, cleaning up unnecessary dependencies.

Submodule removal:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-L3): Removed the `MachineLearning` submodule configuration, including its path and URL.
* [`MachineLearning`](diffhunk://#diff-0b2f6712a50d22428fa17dd1b607c2a64ddad0df953f1534460c70e2428d598eL1): Deleted the submodule commit reference, effectively detaching it from the repository.<!-- 
  Please refer to the Copilot PR overview. Create this PR using the Copilot function.
  Provide any additional field related to the pull request that you might find useful to describe :)
-->

