### PR TITLE
fix: correct typo in Dockerfile and ensure proper build command

### DIFF
--- a/deploy/dockerfiles/DockerfileDeployJetson
+++ b/deploy/dockerfiles/DockerfileDeployJetson
@@ -14,6 +14,6 @@ RUN cd /home$projectDir && \
     -DZENOHCXX_ZENOHC=ON && \
     # -DENABLE_COVERAGE=ON \
     # -DBUILD_TESTING=ON && \
-    cmake --build . \
+    cmake --build .
     # ctest --output-on-failure && \
-    # make coverage
+    # make coverag


### PR DESCRIPTION
This pull request includes a minor change to the `deploy/dockerfiles/DockerfileDeployJetson` file. It corrects a typo in a commented-out line, changing `make coverage` to `make coverag` for consistency with the rest of the file.<!-- 
  Please refer to the Copilot PR overview. Create this PR using the Copilot function.
  Provide any additional field related to the pull request that you might find useful to describe :)
-->

