### PR TITLE
Remove MachineLearning submodule and associated configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "MachineLearning"]
-	path = MachineLearning
-	url = git@github.com:SEAME-pt/Team02-MachineLearning.git


### PR DESCRIPTION
This pull request removes the `MachineLearning` submodule from the repository. The submodule was previously defined in the `.gitmodules` file and referenced a specific commit.

Submodule removal:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-L3): Removed the `MachineLearning` submodule definition, including its path and URL.
* [`MachineLearning`](diffhunk://#diff-0b2f6712a50d22428fa17dd1b607c2a64ddad0df953f1534460c70e2428d598eL1): Deleted the submodule's commit reference.<!-- 
  Please refer to the Copilot PR overview. Create this PR using the Copilot function.
  Provide any additional field related to the pull request that you might find useful to describe :)
-->

